### PR TITLE
feat: Add duration, tags, and video thumbnail support to cloudReposit…

### DIFF
--- a/migrations/000003_add_duration_to_cloud_files.down.sql
+++ b/migrations/000003_add_duration_to_cloud_files.down.sql
@@ -1,0 +1,6 @@
+-- Remove duration index
+DROP INDEX IF EXISTS idx_cloud_files_duration ON cloud_files;
+
+-- Remove duration column from cloud_files table
+ALTER TABLE cloud_files
+DROP COLUMN IF EXISTS duration;

--- a/migrations/000003_add_duration_to_cloud_files.up.sql
+++ b/migrations/000003_add_duration_to_cloud_files.up.sql
@@ -1,0 +1,6 @@
+-- Add duration field to cloud_files table for video length tracking
+ALTER TABLE cloud_files
+ADD COLUMN duration DECIMAL(10,2) NULL COMMENT 'Video duration in seconds';
+
+-- Add index for duration-based queries if needed
+CREATE INDEX idx_cloud_files_duration ON cloud_files(duration) WHERE duration IS NOT NULL;

--- a/services/cloudRepositoryService/features/cloudRepository/handler/routes.go
+++ b/services/cloudRepositoryService/features/cloudRepository/handler/routes.go
@@ -21,7 +21,7 @@ func RegisterRoutes(e *echo.Group, db *gorm.DB, bucket string) {
 	activityHistoryRepo := repository.NewActivityHistoryCloudRepositoryRepository(db)
 
 	// UseCases
-	uploadUC := usecase.NewUploadCloudRepositoryUseCase(uploadRepo, userStatsRepo, 10*time.Second)
+	uploadUC := usecase.NewUploadCloudRepositoryUseCase(uploadRepo, userStatsRepo, db, 10*time.Second)
 	batchUploadUC := usecase.NewBatchUploadCloudRepositoryUseCase(uploadUC, 10*time.Second) // Reuses uploadUC logic
 	downloadUC := usecase.NewDownloadCloudRepositoryUseCase(downloadRepo, userStatsRepo, 10*time.Second)
 	listUC := usecase.NewListCloudRepositoryUseCase(listRepo, 10*time.Second)

--- a/services/cloudRepositoryService/features/cloudRepository/model/entity/cloudFile.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/entity/cloudFile.go
@@ -20,6 +20,7 @@ type CloudFile struct {
 	FileType     FileType   `gorm:"size:20;not null;index" json:"file_type"`
 	ContentType  string     `gorm:"size:100;not null" json:"content_type"`
 	FileSize     int64      `gorm:"not null" json:"file_size"`
+	Duration     *float64   `gorm:"type:decimal(10,2)" json:"duration,omitempty"` // Video duration in seconds
 	Tags         []Tag      `gorm:"many2many:file_tags;" json:"tags,omitempty"`
 	CreatedAt    time.Time  `gorm:"autoCreateTime" json:"created_at"`
 	UpdatedAt    time.Time  `gorm:"autoUpdateTime" json:"updated_at"`

--- a/services/cloudRepositoryService/features/cloudRepository/model/interface/ICloudRepositoryRepository.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/interface/ICloudRepositoryRepository.go
@@ -20,6 +20,7 @@ type IBatchUploadCloudRepositoryRepository interface {
 
 type IDownloadCloudRepositoryRepository interface {
 	GeneratePresignedDownloadURL(ctx context.Context, s3Key string, expiration time.Duration) (string, error)
+	GeneratePresignedDownloadURLWithFilename(ctx context.Context, s3Key, filename string, expiration time.Duration) (string, error)
 	GetFileByID(ctx context.Context, id uint) (*entity.CloudFile, error)
 }
 

--- a/services/cloudRepositoryService/features/cloudRepository/model/request/uploadRequest.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/request/uploadRequest.go
@@ -2,10 +2,12 @@ package request
 
 // UploadRequestDTO for requesting presigned upload URL
 type UploadRequestDTO struct {
-	FileName    string `json:"file_name" validate:"required"`
-	ContentType string `json:"content_type" validate:"required"`
-	FileType    string `json:"file_type" validate:"required,oneof=image video"`
-	FileSize    int64  `json:"file_size" validate:"required,min=1"`
+	FileName    string    `json:"file_name" validate:"required"`
+	ContentType string    `json:"content_type" validate:"required"`
+	FileType    string    `json:"file_type" validate:"required,oneof=image video"`
+	FileSize    int64     `json:"file_size" validate:"required,min=1"`
+	Tags        []string  `json:"tags" validate:"omitempty,dive,max=50"`         // Optional tags (max 50 chars each)
+	Duration    *float64  `json:"duration" validate:"omitempty,min=0,max=86400"` // Optional video duration in seconds (max 24 hours)
 }
 
 // BatchUploadRequestDTO for requesting multiple presigned upload URLs (max 30 files)

--- a/services/cloudRepositoryService/features/cloudRepository/model/response/listFilesResponse.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/response/listFilesResponse.go
@@ -13,6 +13,7 @@ type FileInfoDTO struct {
 	FileType     string   `json:"file_type"`
 	ContentType  string   `json:"content_type"`
 	FileSize     int64    `json:"file_size"`
+	Duration     *float64 `json:"duration,omitempty"` // Video duration in seconds
 	Tags         []TagDTO `json:"tags"`
 	DownloadURL  string   `json:"download_url"`
 	ThumbnailURL string   `json:"thumbnail_url,omitempty"`

--- a/services/cloudRepositoryService/features/cloudRepository/repository/downloadCloudRepository.go
+++ b/services/cloudRepositoryService/features/cloudRepository/repository/downloadCloudRepository.go
@@ -27,6 +27,11 @@ func (r *DownloadCloudRepositoryRepository) GeneratePresignedDownloadURL(ctx con
 	return sharedAws.GeneratePresignedDownloadURL(ctx, r.bucket, s3Key, expiration)
 }
 
+// GeneratePresignedDownloadURLWithFilename generates a presigned URL for downloading with Content-Disposition header
+func (r *DownloadCloudRepositoryRepository) GeneratePresignedDownloadURLWithFilename(ctx context.Context, s3Key, filename string, expiration time.Duration) (string, error) {
+	return sharedAws.GeneratePresignedDownloadURLWithFilename(ctx, r.bucket, s3Key, filename, expiration)
+}
+
 // GetFileByID retrieves a file by ID
 func (r *DownloadCloudRepositoryRepository) GetFileByID(ctx context.Context, id uint) (*entity.CloudFile, error) {
 	var file entity.CloudFile

--- a/services/cloudRepositoryService/features/cloudRepository/usecase/downloadCloudUseCase.go
+++ b/services/cloudRepositoryService/features/cloudRepository/usecase/downloadCloudUseCase.go
@@ -47,8 +47,8 @@ func (u *DownloadCloudRepositoryUseCase) RequestDownloadURL(ctx context.Context,
 		_ = u.StatsRepo.LogActivity(ctx, activity) // Don't fail on logging error
 	}
 
-	// Generate presigned download URL
-	downloadURL, err := u.Repo.GeneratePresignedDownloadURL(ctx, file.S3Key, 1*time.Hour)
+	// Generate presigned download URL with Content-Disposition header for forced download
+	downloadURL, err := u.Repo.GeneratePresignedDownloadURLWithFilename(ctx, file.S3Key, file.FileName, 1*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate download URL: %w", err)
 	}

--- a/services/cloudRepositoryService/features/cloudRepository/usecase/listCloudUseCase.go
+++ b/services/cloudRepositoryService/features/cloudRepository/usecase/listCloudUseCase.go
@@ -82,6 +82,7 @@ func (u *ListCloudRepositoryUseCase) ListFiles(c context.Context, userID uint, r
 			FileType:     string(file.FileType),
 			ContentType:  file.ContentType,
 			FileSize:     file.FileSize,
+			Duration:     file.Duration,
 			Tags:         tagDTOs,
 			DownloadURL:  downloadURL,
 			ThumbnailURL: thumbnailURL,


### PR DESCRIPTION
…oryService

## Changes

### File Upload API
- Add duration field to UploadRequestDTO for video length tracking (seconds)
- Add tags field to UploadRequestDTO for file tagging
- Generate thumbnail keys for both images and videos
- Auto-create/find tags in database with user isolation
- Log tag activities for user stats

### File List API
- Return duration field in FileInfoDTO response
- Return tags array for each file
- Generate thumbnail URLs for videos (not just images)

### Download API
- Add Content-Disposition header to presigned URLs
- Force file download instead of browser display
- Create GeneratePresignedDownloadURLWithFilename function

### Database
- Add duration DECIMAL(10,2) column to cloud_files table
- Tags already exist via many-to-many relationship
- Add migration scripts for duration field

### Core Changes
- CloudFile entity: Add Duration field
- UploadCloudUseCase: Process tags, duration, video thumbnails
- ListCloudUseCase: Return duration field
- DownloadCloudUseCase: Use filename in presigned URLs
- S3 helper: New function with ResponseContentDisposition

## API Changes

POST /api/v1/files/upload/batch
- Accept tags[] and duration fields

GET /api/v1/files
- Return duration, tags, and thumbnail_url for videos

GET /api/v1/files/:id/download
- Include Content-Disposition header for forced download

🤖 Generated with [Claude Code](https://claude.com/claude-code)