### PR TITLE
feat: Add favorites feature for quick file access

### DIFF
--- a/migrations/000004_create_favorites_table.down.sql
+++ b/migrations/000004_create_favorites_table.down.sql
@@ -1,0 +1,2 @@
+-- Rollback: Drop favorites table
+DROP TABLE IF EXISTS favorites;

--- a/migrations/000004_create_favorites_table.up.sql
+++ b/migrations/000004_create_favorites_table.up.sql
@@ -1,0 +1,20 @@
+-- Create favorites table for bookmarking files
+CREATE TABLE favorites (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  user_id BIGINT UNSIGNED NOT NULL,
+  file_id BIGINT UNSIGNED NOT NULL,
+  favorited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  -- Prevent duplicate favorites
+  UNIQUE KEY uniq_user_file (user_id, file_id),
+
+  -- Optimize queries for user's favorites list
+  INDEX idx_user_favorited_at (user_id, favorited_at),
+  INDEX idx_user_fileid (user_id, file_id),
+
+  -- Auto-cleanup when user or file is deleted
+  CONSTRAINT fk_fav_user FOREIGN KEY (user_id)
+    REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT fk_fav_file FOREIGN KEY (file_id)
+    REFERENCES cloud_files(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/services/cloudRepositoryService/features/cloudRepository/handler/favoriteHandler.go
+++ b/services/cloudRepositoryService/features/cloudRepository/handler/favoriteHandler.go
@@ -1,0 +1,143 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	_interface "github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/interface"
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/request"
+	"github.com/labstack/echo/v4"
+)
+
+type FavoriteHandler struct {
+	UseCase _interface.IFavoriteUseCase
+}
+
+func NewFavoriteHandler(c *echo.Group, useCase _interface.IFavoriteUseCase) *FavoriteHandler {
+	handler := &FavoriteHandler{
+		UseCase: useCase,
+	}
+	c.POST("/favorites", handler.AddFavorite)
+	c.DELETE("/favorites/:fileId", handler.RemoveFavorite)
+	c.GET("/favorites", handler.ListFavorites)
+	return handler
+}
+
+// AddFavorite handles adding a file to favorites
+// @Summary Add file to favorites
+// @Description Add a file to user's favorites list
+// @Tags Favorites
+// @Accept json
+// @Produce json
+// @Param body body request.AddFavoriteRequestDTO true "Add favorite request"
+// @Success 200 {object} response.FavoriteResponseDTO
+// @Failure 400 {object} map[string]string
+// @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/v1/favorites [post]
+func (h *FavoriteHandler) AddFavorite(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+	}
+
+	var req request.AddFavoriteRequestDTO
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+	}
+
+	if err := c.Validate(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	resp, err := h.UseCase.AddFavorite(ctx, userID, req.FileID)
+	if err != nil {
+		// Determine appropriate status code based on error message
+		statusCode := http.StatusInternalServerError
+		if strings.Contains(err.Error(), "not found") {
+			statusCode = http.StatusNotFound
+		} else if strings.Contains(err.Error(), "access denied") || strings.Contains(err.Error(), "do not own") {
+			statusCode = http.StatusForbidden
+		}
+		return c.JSON(statusCode, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// RemoveFavorite handles removing a file from favorites
+// @Summary Remove file from favorites
+// @Description Remove a file from user's favorites list
+// @Tags Favorites
+// @Accept json
+// @Produce json
+// @Param fileId path int true "File ID"
+// @Success 204 "No Content"
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/v1/favorites/{fileId} [delete]
+func (h *FavoriteHandler) RemoveFavorite(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+	}
+
+	fileID, err := strconv.ParseUint(c.Param("fileId"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid file ID"})
+	}
+
+	if err := h.UseCase.RemoveFavorite(ctx, userID, uint(fileID)); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// ListFavorites handles listing all favorited files
+// @Summary List favorite files
+// @Description List all files in user's favorites with filtering and pagination
+// @Tags Favorites
+// @Accept json
+// @Produce json
+// @Param page query int false "Page number (default: 1)"
+// @Param size query int false "Page size (default: 20, max: 100)"
+// @Param sort query string false "Sort field (uploadDate, fileName)"
+// @Param order query string false "Sort order (asc, desc)"
+// @Param q query string false "Filename search"
+// @Param ext query string false "File extension filter"
+// @Param tag query string false "Tag filter"
+// @Success 200 {object} response.ListFavoritesResponseDTO
+// @Failure 400 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /api/v1/favorites [get]
+func (h *FavoriteHandler) ListFavorites(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+	}
+
+	var filter request.ListFavoritesRequestDTO
+	if err := c.Bind(&filter); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid query parameters"})
+	}
+
+	if err := c.Validate(&filter); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	resp, err := h.UseCase.ListFavorites(ctx, userID, filter)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}

--- a/services/cloudRepositoryService/features/cloudRepository/handler/routes.go
+++ b/services/cloudRepositoryService/features/cloudRepository/handler/routes.go
@@ -19,6 +19,7 @@ func RegisterRoutes(e *echo.Group, db *gorm.DB, bucket string) {
 	deleteRepo := repository.NewDeleteCloudRepositoryRepository(db, bucket)
 	userStatsRepo := repository.NewUserStatsCloudRepositoryRepository(db)
 	activityHistoryRepo := repository.NewActivityHistoryCloudRepositoryRepository(db)
+	favoriteRepo := repository.NewFavoriteRepository(db)
 
 	// UseCases
 	uploadUC := usecase.NewUploadCloudRepositoryUseCase(uploadRepo, userStatsRepo, db, 10*time.Second)
@@ -28,6 +29,7 @@ func RegisterRoutes(e *echo.Group, db *gorm.DB, bucket string) {
 	deleteUC := usecase.NewDeleteCloudRepositoryUseCase(deleteRepo, 10*time.Second)
 	userStatsUC := usecase.NewUserStatsCloudRepositoryUseCase(userStatsRepo, 10*time.Second)
 	activityHistoryUC := usecase.NewActivityHistoryCloudRepositoryUseCase(activityHistoryRepo, 10*time.Second)
+	favoriteUC := usecase.NewFavoriteUseCase(favoriteRepo, downloadRepo, listRepo, 10*time.Second)
 
 	// Handlers
 	NewUploadCloudRepositoryHandler(e, uploadUC)
@@ -37,5 +39,6 @@ func RegisterRoutes(e *echo.Group, db *gorm.DB, bucket string) {
 	NewDeleteCloudRepositoryHandler(e, deleteUC)
 	NewUserStatsCloudRepositoryHandler(e, userStatsUC)
 	NewActivityHistoryCloudRepositoryHandler(e, activityHistoryUC)
+	NewFavoriteHandler(e, favoriteUC)
 
 }

--- a/services/cloudRepositoryService/features/cloudRepository/model/entity/favorite.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/entity/favorite.go
@@ -1,0 +1,16 @@
+package entity
+
+import "time"
+
+// Favorite represents a user's favorited file
+type Favorite struct {
+	ID          uint      `gorm:"primaryKey" json:"id"`
+	UserID      uint      `gorm:"not null;index:idx_user_favorited_at" json:"user_id"`
+	FileID      uint      `gorm:"not null;uniqueIndex:uniq_user_file" json:"file_id"`
+	FavoritedAt time.Time `gorm:"autoCreateTime" json:"favorited_at"`
+}
+
+// TableName specifies the table name for Favorite
+func (Favorite) TableName() string {
+	return "favorites"
+}

--- a/services/cloudRepositoryService/features/cloudRepository/model/interface/IFavoriteRepository.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/interface/IFavoriteRepository.go
@@ -1,0 +1,16 @@
+package _interface
+
+import (
+	"context"
+
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/entity"
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/request"
+)
+
+// IFavoriteRepository defines methods for favorite operations
+type IFavoriteRepository interface {
+	AddFavorite(ctx context.Context, userID, fileID uint) (*entity.Favorite, error)
+	RemoveFavorite(ctx context.Context, userID, fileID uint) error
+	GetFavoritesByUserID(ctx context.Context, userID uint, filter request.ListFavoritesRequestDTO) ([]entity.CloudFile, int64, error)
+	CheckIsFavorited(ctx context.Context, userID, fileID uint) (bool, error)
+}

--- a/services/cloudRepositoryService/features/cloudRepository/model/interface/IFavoriteUseCase.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/interface/IFavoriteUseCase.go
@@ -1,0 +1,15 @@
+package _interface
+
+import (
+	"context"
+
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/request"
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/response"
+)
+
+// IFavoriteUseCase defines methods for favorite business logic
+type IFavoriteUseCase interface {
+	AddFavorite(ctx context.Context, userID, fileID uint) (*response.FavoriteResponseDTO, error)
+	RemoveFavorite(ctx context.Context, userID, fileID uint) error
+	ListFavorites(ctx context.Context, userID uint, filter request.ListFavoritesRequestDTO) (*response.ListFavoritesResponseDTO, error)
+}

--- a/services/cloudRepositoryService/features/cloudRepository/model/request/favoriteRequest.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/request/favoriteRequest.go
@@ -1,0 +1,17 @@
+package request
+
+// AddFavoriteRequestDTO for adding a file to favorites
+type AddFavoriteRequestDTO struct {
+	FileID uint `json:"fileId" validate:"required,min=1"`
+}
+
+// ListFavoritesRequestDTO for listing favorites with pagination and filtering
+type ListFavoritesRequestDTO struct {
+	Page  int    `query:"page" validate:"omitempty,min=1"`
+	Size  int    `query:"size" validate:"omitempty,min=1,max=100"`
+	Sort  string `query:"sort" validate:"omitempty,oneof=uploadDate fileName"`
+	Order string `query:"order" validate:"omitempty,oneof=asc desc"`
+	Q     string `query:"q" validate:"omitempty,max=255"`     // Filename search
+	Ext   string `query:"ext" validate:"omitempty,max=10"`    // File extension filter
+	Tag   string `query:"tag" validate:"omitempty,max=50"`    // Tag filter
+}

--- a/services/cloudRepositoryService/features/cloudRepository/model/response/favoriteResponse.go
+++ b/services/cloudRepositoryService/features/cloudRepository/model/response/favoriteResponse.go
@@ -1,0 +1,23 @@
+package response
+
+import "time"
+
+// FavoriteResponseDTO for add/remove favorite operations
+type FavoriteResponseDTO struct {
+	Success     bool      `json:"success"`
+	FavoritedAt time.Time `json:"favoritedAt"`
+}
+
+// PaginationMeta represents pagination metadata
+type PaginationMeta struct {
+	Total      int64 `json:"total"`
+	Page       int   `json:"page"`
+	Size       int   `json:"size"`
+	TotalPages int   `json:"total_pages"`
+}
+
+// ListFavoritesResponseDTO for listing favorite files
+type ListFavoritesResponseDTO struct {
+	Data       []FileInfoDTO  `json:"data"`
+	Pagination PaginationMeta `json:"pagination"`
+}

--- a/services/cloudRepositoryService/features/cloudRepository/repository/favoriteRepository.go
+++ b/services/cloudRepositoryService/features/cloudRepository/repository/favoriteRepository.go
@@ -1,0 +1,122 @@
+package repository
+
+import (
+	"context"
+	"strings"
+
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/entity"
+	_interface "github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/interface"
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/request"
+	"gorm.io/gorm"
+)
+
+type FavoriteRepository struct {
+	db *gorm.DB
+}
+
+func NewFavoriteRepository(db *gorm.DB) _interface.IFavoriteRepository {
+	return &FavoriteRepository{
+		db: db,
+	}
+}
+
+// AddFavorite creates a new favorite record (idempotent using FirstOrCreate)
+func (r *FavoriteRepository) AddFavorite(ctx context.Context, userID, fileID uint) (*entity.Favorite, error) {
+	favorite := &entity.Favorite{
+		UserID: userID,
+		FileID: fileID,
+	}
+	// FirstOrCreate is idempotent - returns existing or creates new
+	err := r.db.WithContext(ctx).
+		Where("user_id = ? AND file_id = ?", userID, fileID).
+		FirstOrCreate(favorite).Error
+	return favorite, err
+}
+
+// RemoveFavorite deletes a favorite record (idempotent - no error if not exists)
+func (r *FavoriteRepository) RemoveFavorite(ctx context.Context, userID, fileID uint) error {
+	// Delete returns no error even if record doesn't exist (0 rows affected)
+	return r.db.WithContext(ctx).
+		Where("user_id = ? AND file_id = ?", userID, fileID).
+		Delete(&entity.Favorite{}).Error
+}
+
+// GetFavoritesByUserID retrieves all favorited files for a user with filtering and pagination
+func (r *FavoriteRepository) GetFavoritesByUserID(ctx context.Context, userID uint, filter request.ListFavoritesRequestDTO) ([]entity.CloudFile, int64, error) {
+	var files []entity.CloudFile
+	var total int64
+
+	// Build query with JOIN to get file details
+	query := r.db.WithContext(ctx).
+		Model(&entity.CloudFile{}).
+		Preload("Tags"). // Eager load tags
+		Joins("INNER JOIN favorites ON cloud_files.id = favorites.file_id").
+		Where("favorites.user_id = ? AND cloud_files.deleted_at IS NULL", userID)
+
+	// Apply filename search filter
+	if filter.Q != "" {
+		query = query.Where("cloud_files.file_name LIKE ?", "%"+filter.Q+"%")
+	}
+
+	// Apply extension filter
+	if filter.Ext != "" {
+		// Extension should match the file extension (case-insensitive)
+		ext := strings.TrimPrefix(filter.Ext, ".")
+		query = query.Where("LOWER(cloud_files.file_name) LIKE ?", "%."+strings.ToLower(ext))
+	}
+
+	// Apply tag filter
+	if filter.Tag != "" {
+		query = query.Where("cloud_files.id IN (SELECT cloud_file_id FROM file_tags JOIN tags ON tags.id = file_tags.tag_id WHERE tags.name = ?)", filter.Tag)
+	}
+
+	// Get total count before pagination
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	// Apply sorting
+	sortField := "favorites.favorited_at" // Default sort by when favorited
+	if filter.Sort == "fileName" {
+		sortField = "cloud_files.file_name"
+	} else if filter.Sort == "uploadDate" {
+		sortField = "cloud_files.created_at"
+	}
+
+	sortOrder := "DESC"
+	if filter.Order == "asc" {
+		sortOrder = "ASC"
+	}
+	query = query.Order(sortField + " " + sortOrder)
+
+	// Apply pagination
+	page := filter.Page
+	if page < 1 {
+		page = 1
+	}
+	pageSize := filter.Size
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+
+	offset := (page - 1) * pageSize
+	err := query.Limit(pageSize).Offset(offset).Find(&files).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return files, total, nil
+}
+
+// CheckIsFavorited checks if a file is favorited by a user
+func (r *FavoriteRepository) CheckIsFavorited(ctx context.Context, userID, fileID uint) (bool, error) {
+	var count int64
+	err := r.db.WithContext(ctx).
+		Model(&entity.Favorite{}).
+		Where("user_id = ? AND file_id = ?", userID, fileID).
+		Count(&count).Error
+	return count > 0, err
+}

--- a/services/cloudRepositoryService/features/cloudRepository/usecase/favoriteUseCase.go
+++ b/services/cloudRepositoryService/features/cloudRepository/usecase/favoriteUseCase.go
@@ -1,0 +1,152 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	_interface "github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/interface"
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/request"
+	"github.com/JokerTrickster/joker_backend/services/cloudRepositoryService/features/cloudRepository/model/response"
+)
+
+type FavoriteUseCase struct {
+	FavoriteRepo   _interface.IFavoriteRepository
+	FileRepo       _interface.IDownloadCloudRepositoryRepository // For file validation and ownership
+	ListRepo       _interface.IListCloudRepositoryRepository     // For presigned URL generation
+	ContextTimeout time.Duration
+}
+
+func NewFavoriteUseCase(
+	favoriteRepo _interface.IFavoriteRepository,
+	fileRepo _interface.IDownloadCloudRepositoryRepository,
+	listRepo _interface.IListCloudRepositoryRepository,
+	timeout time.Duration,
+) _interface.IFavoriteUseCase {
+	return &FavoriteUseCase{
+		FavoriteRepo:   favoriteRepo,
+		FileRepo:       fileRepo,
+		ListRepo:       listRepo,
+		ContextTimeout: timeout,
+	}
+}
+
+// AddFavorite validates file exists and user owns it, then adds to favorites
+func (u *FavoriteUseCase) AddFavorite(c context.Context, userID, fileID uint) (*response.FavoriteResponseDTO, error) {
+	ctx, cancel := context.WithTimeout(c, u.ContextTimeout)
+	defer cancel()
+
+	// Validate file exists
+	file, err := u.FileRepo.GetFileByID(ctx, fileID)
+	if err != nil {
+		return nil, fmt.Errorf("file not found")
+	}
+
+	// Verify ownership
+	if file.UserID != userID {
+		return nil, fmt.Errorf("access denied: you do not own this file")
+	}
+
+	// Add favorite (idempotent - won't error if already favorited)
+	favorite, err := u.FavoriteRepo.AddFavorite(ctx, userID, fileID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add favorite: %w", err)
+	}
+
+	return &response.FavoriteResponseDTO{
+		Success:     true,
+		FavoritedAt: favorite.FavoritedAt,
+	}, nil
+}
+
+// RemoveFavorite removes a file from favorites (idempotent)
+func (u *FavoriteUseCase) RemoveFavorite(c context.Context, userID, fileID uint) error {
+	ctx, cancel := context.WithTimeout(c, u.ContextTimeout)
+	defer cancel()
+
+	// Idempotent - no error if favorite doesn't exist
+	return u.FavoriteRepo.RemoveFavorite(ctx, userID, fileID)
+}
+
+// ListFavorites retrieves favorited files with presigned URLs and pagination
+func (u *FavoriteUseCase) ListFavorites(c context.Context, userID uint, filter request.ListFavoritesRequestDTO) (*response.ListFavoritesResponseDTO, error) {
+	ctx, cancel := context.WithTimeout(c, u.ContextTimeout)
+	defer cancel()
+
+	// Set defaults
+	if filter.Page < 1 {
+		filter.Page = 1
+	}
+	if filter.Size < 1 {
+		filter.Size = 20
+	}
+	if filter.Size > 100 {
+		filter.Size = 100
+	}
+
+	// Get favorited files
+	files, total, err := u.FavoriteRepo.GetFavoritesByUserID(ctx, userID, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list favorites: %w", err)
+	}
+
+	// Generate presigned URLs for each file
+	fileInfos := make([]response.FileInfoDTO, len(files))
+	for i, file := range files {
+		// Map tags
+		tagDTOs := make([]response.TagDTO, len(file.Tags))
+		for j, tag := range file.Tags {
+			tagDTOs[j] = response.TagDTO{
+				ID:   tag.ID,
+				Name: tag.Name,
+			}
+		}
+
+		// Generate presigned download URL
+		downloadURL, err := u.ListRepo.GeneratePresignedDownloadURL(ctx, file.S3Key, 1*time.Hour)
+		if err != nil {
+			// Log error but don't fail the entire request
+			downloadURL = ""
+		}
+
+		// Generate presigned thumbnail URL if available
+		thumbnailURL := ""
+		if file.ThumbnailKey != "" {
+			thumbnailURL, err = u.ListRepo.GeneratePresignedDownloadURL(ctx, file.ThumbnailKey, 1*time.Hour)
+			if err != nil {
+				// Log error but don't fail the entire request
+				thumbnailURL = ""
+			}
+		}
+
+		fileInfos[i] = response.FileInfoDTO{
+			ID:           file.ID,
+			FileName:     file.FileName,
+			FileType:     string(file.FileType),
+			ContentType:  file.ContentType,
+			FileSize:     file.FileSize,
+			Duration:     file.Duration,
+			Tags:         tagDTOs,
+			DownloadURL:  downloadURL,
+			ThumbnailURL: thumbnailURL,
+			CreatedAt:    file.CreatedAt.Format(time.RFC3339),
+			UpdatedAt:    file.UpdatedAt.Format(time.RFC3339),
+		}
+	}
+
+	// Calculate total pages
+	totalPages := int(total) / filter.Size
+	if int(total)%filter.Size != 0 {
+		totalPages++
+	}
+
+	return &response.ListFavoritesResponseDTO{
+		Data: fileInfos,
+		Pagination: response.PaginationMeta{
+			Total:      total,
+			Page:       filter.Page,
+			Size:       filter.Size,
+			TotalPages: totalPages,
+		},
+	}, nil
+}


### PR DESCRIPTION
## Summary
즐겨찾기(Favorites) 기능 구현

사용자가 자주 사용하는 이미지/동영상 파일을 즐겨찾기에 추가하고, 빠르게 접근할 수 있는 기능입니다.

## Changes

### Database
- ✅ Migration: `000004_create_favorites_table` 추가
- ✅ `favorites` 테이블: user_id, file_id, favorited_at
- ✅ UNIQUE 제약조건으로 중복 방지
- ✅ CASCADE DELETE로 자동 정리

### Backend Implementation
- ✅ **Entity**: `model/entity/favorite.go`
- ✅ **DTOs**: Request/Response 모델
- ✅ **Repository**: GORM 기반 DB 작업 (AddFavorite, RemoveFavorite, GetFavoritesByUserID, CheckIsFavorited)
- ✅ **UseCase**: 비즈니스 로직 (파일 소유권 검증, presigned URL 생성)
- ✅ **Handler**: 3개 REST API 엔드포인트

### API Endpoints
- `POST /api/v1/favorites` - 즐겨찾기 추가 (idempotent)
- `DELETE /api/v1/favorites/:fileId` - 즐겨찾기 제거 (idempotent)  
- `GET /api/v1/favorites` - 즐겨찾기 목록 조회 (pagination, filtering, sorting)

### Key Features
- 🔒 JWT 인증 필수
- 🔄 Idempotent 작업 (중복 호출 안전)
- 📄 페이지네이션 지원 (기본 20개, 최대 100개)
- 🔍 필터링: 파일명, 확장자, 태그
- 📊 정렬: 업로드 날짜, 파일명
- 🔗 Presigned URL 자동 생성 (1시간 유효)

## Testing
- Manual testing required after deployment
- Frontend integration testing needed

## Related Issues
Closes #21, #22, #23, #24, #25, #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
